### PR TITLE
Fixed "Request method 'POST' not supported" bug - Update client.py

### DIFF
--- a/python_picnic_api/client.py
+++ b/python_picnic_api/client.py
@@ -83,8 +83,7 @@ class PicnicAPI:
 
     def get_delivery(self, deliveryId: str):
         path = "/deliveries/" + deliveryId
-        data = []
-        return self._post(path, data=data)
+        return self._get(path)
 
     def get_deliveries(self, summary: bool = False):
         data = []


### PR DESCRIPTION
Picnic made changes to their api, if I tried to get a delivery, I got the following error: "Request method 'POST' not supported". This error is fixed by making a get request, instead of a post request.