### PR TITLE
Switch to poetry-core

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,5 +18,5 @@ black = {version = "^19.10b0", allow-prereleases = true}
 python-dotenv = "^0.15.0"
 
 [build-system]
-requires = ["poetry>=0.12"]
-build-backend = "poetry.masonry.api"
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
[`poetry-core`](https://github.com/python-poetry/poetry-core) is intended to be a light weight, fully compliant, self-contained package allowing PEP 517 compatible build frontends to build Poetry managed projects.

Using `poetry-core` allows distribution packages to depend only on the build backend.